### PR TITLE
Use VS Code Task Api

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,89 @@ Open the Command Palette (Command+Shift+P on Mac and Ctrl+Shift+P on Windows/Lin
 | `Flamegraph: Profile unit tests in file with pytest` | Run and profile the `pytest` command on the active file |
 | `Flamegraph: Show py-spy top` | Displays a top like view of functions consuming CPU using py-spy |
 
+
+
+## Using Tasks
+
+The extension allows you to run profiling tasks directly from VS Code's task system. This makes it easy to integrate profiling into your workflow and configure custom tasks.
+
+### Using the Task Explorer
+
+1. Open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on macOS)
+2. Type "Tasks: Run Task" and select "flamegraph"
+3. Choose one of the available flamegraph tasks or click the gear icon to customize the task.
+
+### Creating a tasks.json File
+
+You can also create a `tasks.json` file in your `.vscode` folder to customize the tasks. For example, the following task
+
+
+
+```json
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "flamegraph",
+			"file": "${file}",
+			"args": [
+				"--my-custom-arg1",
+				"value",
+			],
+			"label": "Flamegraph: My custom profile command"
+		}
+	]
+}
+```
+
+will execute the command
+
+```py-spy <py-spy-args> -- python <current-file> --my-custom-arg1 value```.
+
+As another example, we can profile a specific unit test with the following task definition:
+
+
+```json
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "flamegraph",
+			"args": [
+				"-m",
+				"pytest",
+				"path/to/my_test_file.py::test_my_function",
+			],
+			"subprocesses": false,
+			"native": true,
+			"label": "Flamegraph: Profile my_test_function"
+		}
+	]
+}
+```
+
+Notice that we additionally configured the py-spy subprocess and native options. This will execute the command
+
+```py-spy <py-spy-args> --native -- python -m pytest path/to/my_test_file.py::test_my_function```
+
+
+
+### Setting custom keyboard shortcuts
+
+You can bind tasks to keyboard shortcuts by adding entries to your `keybindings.json` file:
+
+1. Open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on macOS)
+2. Type "Preferences: Open Keyboard Shortcuts (JSON)" and select it
+3. Add entries like the following:
+
+```json
+{
+    "key": "ctrl+shift+enter",
+    "command": "workbench.action.tasks.runTask",
+    "args": "Flamegraph: My custom profile command"
+}
+```
+
 ## Contributing
 
 ### Development

--- a/package.json
+++ b/package.json
@@ -92,6 +92,56 @@
                 "title": "Flamegraph: Show py-spy top"
             }
         ],
+        "taskDefinitions": [
+            {
+                "type": "flamegraph",
+                "properties": {
+                    "mode": {
+                        "type": "string",
+                        "description": "The mode of the task (should be 'record' or 'top')",
+                        "default": "record",
+                        "enum": [
+                            "record",
+                            "top"
+                        ]
+                    },
+                    "file": {
+                        "type": "string",
+                        "description": "The file to profile (optional)"
+                    },
+                    "pid": {
+                        "type": "string",
+                        "description": "The process ID (PID) to attach to, if no file is provided (optional)"
+                    },
+                    "subprocesses": {
+                        "type": "boolean",
+                        "description": "Profile subprocesses (optional)",
+                        "default": true
+                    },
+                    "native": {
+                        "type": "boolean",
+                        "description": "Use native profiling (optional)",
+                        "default": false
+                    },
+                    "args": {
+                        "type": "array",
+                        "description": "The arguments to pass to the profiler (optional)",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "pythonPath": {
+                        "type": "string",
+                        "description": "The path to the Python interpreter. If not provided, the path will be retrieved from currently active environment selected in the VS Code Python extension."
+                    },
+                    "profilerPath": {
+                        "type": "string",
+                        "description": "The path to py-spy. If not provided, either the global py-spy installation will be used or the py-spy found in the currently active environment."
+                    }
+                },
+                "when": "shellExecutionSupported"
+            }
+        ],
         "menus": {
             "explorer/context": [
                 {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -181,6 +181,7 @@ export async function attach(
             pid: verifiedPid,
             native,
             subprocesses,
+            sudo: requireSudoAccess,
         },
         TASK_TERMINAL_NAME,
         silent

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,48 +1,13 @@
 import * as vscode from 'vscode';
 import { commands } from 'vscode';
-import * as path from 'path';
 import * as os from 'os';
-import {
-    getPythonPath,
-    selectProfileFile,
-    readTextFile,
-    promptUserToOpenFolder,
-    getPidAndCellFilenameMap,
-    getOrInstallPySpyWithSudo,
-    selectPid,
-} from './utilities/fsUtils';
+import { selectProfileFile, readTextFile, getPidAndCellFilenameMap, verify } from './utilities/fsUtils';
 import { FlamegraphPanel } from './flamegraphPanel';
 import { extensionState } from './state';
 import { Flamegraph } from './flamegraph';
-import { NotebookCellMap } from './types';
-import { escapeSpaces } from './utilities/pathUtils';
+import { createProfileTask } from './taskProvider';
 
 const TASK_TERMINAL_NAME = 'Py-spy profile'; // Name of the terminal launched for the profiling task
-
-/**
- * Handles the profile update event. This is called when a new profile is written to the file system.
- *
- * @param context - The extension context.
- * @param profileUri - The URI of the profile file.
- */
-const handleProfileUpdate = async (
-    context: vscode.ExtensionContext,
-    profileUri: vscode.Uri,
-    filenameToJupyterCellMap?: NotebookCellMap
-) => {
-    try {
-        extensionState.currentFlamegraph = new Flamegraph(await readTextFile(profileUri), filenameToJupyterCellMap);
-        extensionState.profileUri = profileUri;
-        extensionState.focusNode = [0];
-        extensionState.profileVisible = true;
-        extensionState.updateUI();
-        FlamegraphPanel.render(context.extensionUri);
-    } catch (error) {
-        vscode.window.showErrorMessage(`Failed to open profile: ${error}`);
-    }
-    // Cleanup watcher after profile is loaded
-    extensionState.activeProfileWatcher = undefined;
-};
 
 /**
  * Loads a profile from a file specified by the user.
@@ -95,204 +60,154 @@ export function toggleProfileCommand() {
 }
 
 /**
- * Create a new vscode task to run py-spy and monitor the profile file.
+ * Runs the profiler on the active file.
  *
- * @param context - The extension context.
- * @param workspaceFolder - The workspace folder.
- * @param pySpyPath - The path to py-spy.
- * @param command - The command to run.
- * @param flags - The flags to pass to py-spy.
- * @param useSudo - Whether to run the command with sudo.
- * @param filenameToJupyterCellMap - A map of filenames to Jupyter cell indices.
  * @returns The command registration.
  */
-async function runTask(
-    context: vscode.ExtensionContext,
-    workspaceFolder: vscode.WorkspaceFolder,
-    pySpyPath: string,
-    command: string,
-    flags: string,
-    useSudo: boolean,
-    filenameToJupyterCellMap?: NotebookCellMap
-): Promise<void> {
-    const profileFileName = 'profile.pyspy';
-    const profilePath = path.join(workspaceFolder.uri.fsPath, profileFileName);
-    const profileUri = vscode.Uri.file(profilePath);
+export function runProfilerCommand() {
+    return vscode.commands.registerCommand('flamegraph.runProfiler', async (fileUri?: vscode.Uri) => {
+        const result = await verify({
+            requireUri: true,
+            requirePython: true,
+            recommendSudo: true,
+            requireSudo: false,
+            requirePid: false,
+            fileUri: fileUri || vscode.window.activeTextEditor?.document.uri,
+        });
+        if (!result) return;
 
-    // Setup file watcher
-    if (!extensionState.activeProfileWatcher) {
-        const watcher = vscode.workspace.createFileSystemWatcher(
-            new vscode.RelativePattern(workspaceFolder, 'profile.pyspy')
-        );
-        extensionState.activeProfileWatcher = watcher;
-    }
+        const { uri, pythonPath, pySpyPath, workspaceFolder } = result;
 
-    extensionState.activeProfileWatcher.onDidCreate(async () =>
-        handleProfileUpdate(context, profileUri, filenameToJupyterCellMap)
-    );
-    extensionState.activeProfileWatcher.onDidChange(async () =>
-        handleProfileUpdate(context, profileUri, filenameToJupyterCellMap)
-    );
-
-    const sudo = useSudo ? 'sudo ' : '';
-    const ampersand = os.platform() === 'win32' ? '& ' : '';
-
-    // Create task definition
-    const taskDefinition: vscode.TaskDefinition = {
-        type: 'shell',
-        command: escapeSpaces(
-            `${ampersand}${sudo}"${pySpyPath}" record --output ${profileFileName} --format raw --full-filenames ${flags} ${command}`
-        ),
-    };
-
-    const task = new vscode.Task(
-        taskDefinition,
-        workspaceFolder,
-        TASK_TERMINAL_NAME,
-        'py-spy',
-        // Create the task with PowerShell on Windows Unix-like terminal (git bash) will cause errors
-        new vscode.ShellExecution(taskDefinition.command, {
-            executable: os.platform() === 'win32' ? 'powershell.exe' : undefined,
-        }),
-        []
-    );
-
-    // Execute the task
-    await vscode.tasks.executeTask(task);
-}
-
-async function runCommand(
-    context: vscode.ExtensionContext,
-    fileUri?: vscode.Uri,
-    requireUri: boolean = true,
-    option: string = ''
-) {
-    // If called with a file URI, use that file. Otherwise, use the uri from the active editor
-    let targetUri: vscode.Uri | undefined;
-    if (requireUri || fileUri) {
-        if (fileUri) {
-            targetUri = fileUri;
-        } else {
-            const editor = vscode.window.activeTextEditor;
-            if (!editor) {
-                vscode.window.showErrorMessage(
-                    'No file is currently selected. Please open a Python file in an editor tab and try again.'
-                );
-                return;
-            }
-            targetUri = editor.document.uri;
-        }
-
-        if (!targetUri.fsPath.endsWith('.py')) {
-            vscode.window.showErrorMessage(
-                'Only Python files are supported. Please open a Python file in an editor tab and try again.'
-            );
-            return;
-        }
-    }
-
-    const workspaceFolder = targetUri
-        ? vscode.workspace.getWorkspaceFolder(targetUri)
-        : vscode.workspace.workspaceFolders?.[0];
-    if (!workspaceFolder) {
-        promptUserToOpenFolder(targetUri);
-        return;
-    }
-
-    const pythonPath = await getPythonPath();
-    if (!pythonPath) {
-        vscode.window.showErrorMessage('No Python interpreter selected. Please select a Python interpreter.');
-        return;
-    }
-
-    const needsSudoAccess = os.platform() === 'darwin';
-    const pySpyPath = await getOrInstallPySpyWithSudo(needsSudoAccess, false);
-    if (!pySpyPath) return;
-
-    const filePath = targetUri?.fsPath ?? '';
-    const command = `-- "${pythonPath}" ${option} "${filePath}"`;
-    const flags = '--subprocesses';
-    runTask(context, workspaceFolder, pySpyPath, command, flags, needsSudoAccess);
+        const task = createProfileTask(workspaceFolder, {
+            type: 'flamegraph',
+            file: uri!.fsPath,
+            pythonPath,
+            profilerPath: pySpyPath,
+        });
+        await vscode.tasks.executeTask(task);
+    });
 }
 
 /**
- * Runs the profiler on the active file.
+ * Profiles all pytests in the active file.
  *
- * @param context - The extension context.
  * @returns The command registration.
  */
-export function runProfilerCommand(context: vscode.ExtensionContext) {
-    return vscode.commands.registerCommand('flamegraph.runProfiler', async (fileUri?: vscode.Uri) => {
-        await runCommand(context, fileUri);
-    });
-}
-
-export function runPytestFileCommand(context: vscode.ExtensionContext) {
+export function runPytestFileCommand() {
     return vscode.commands.registerCommand('flamegraph.runPytestFile', async (fileUri?: vscode.Uri) => {
-        await runCommand(context, fileUri, true, '-m pytest');
+        const result = await verify({
+            requireUri: true,
+            requirePython: true,
+            recommendSudo: true,
+            requireSudo: false,
+            requirePid: false,
+            fileUri: fileUri || vscode.window.activeTextEditor?.document.uri,
+        });
+        if (!result) return;
+
+        const { uri, pythonPath, pySpyPath, workspaceFolder } = result;
+
+        const task = createProfileTask(workspaceFolder, {
+            type: 'flamegraph',
+            pythonPath,
+            profilerPath: pySpyPath,
+            command: ['-m', 'pytest', uri!.fsPath],
+        });
+        await vscode.tasks.executeTask(task);
     });
 }
 
-export function runAllPytestsCommand(context: vscode.ExtensionContext) {
+/**
+ * Runs all pytests in the workspace.
+ *
+ * @returns The command registration.
+ */
+export function runAllPytestsCommand() {
     return vscode.commands.registerCommand('flamegraph.runAllPytests', async () => {
-        await runCommand(context, undefined, false, '-m pytest');
+        const result = await verify({
+            requireUri: false,
+            requirePython: true,
+            recommendSudo: true,
+            requireSudo: false,
+            requirePid: false,
+        });
+        if (!result) return;
+
+        const { pythonPath, pySpyPath, workspaceFolder } = result;
+
+        const task = createProfileTask(workspaceFolder, {
+            type: 'flamegraph',
+            pythonPath,
+            pySpyPath,
+            command: ['-m', 'pytest'],
+        });
+        await vscode.tasks.executeTask(task);
     });
 }
 
 /**
  * Attaches py-spy to the running process.
  *
- * @param context - The extension context.
- * @param flags - The flags to pass to py-spy, such as --subprocesses or --native.
  * @param pid - The process ID (PID) to attach py-spy to.
- * @param filenameToJupyterCellMap - A map of filenames to Jupyter cell indices.
+ * @param subprocesses - Whether to attach py-spy to subprocesses.
+ * @param native - Whether to attach py-spy to the native process.
+ * @param requireSudoAccess - Whether to require sudo access.
  * @returns The command registration.
  */
 export async function attach(
-    context: vscode.ExtensionContext,
-    flags: string,
     pid?: string,
-    filenameToJupyterCellMap?: NotebookCellMap,
-    requireSudoAccess: boolean = false
+    subprocesses: boolean = true,
+    native: boolean = false,
+    requireSudoAccess: boolean = false,
+    silent: boolean = false
 ): Promise<boolean> {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    if (!workspaceFolder) {
-        promptUserToOpenFolder();
-        return false;
-    }
-    const needsSudoAccess = os.platform() === 'darwin' || os.platform() === 'linux';
-    const pySpyPath = await getOrInstallPySpyWithSudo(needsSudoAccess, requireSudoAccess);
-    if (!pySpyPath) return false;
+    const result = await verify({
+        requireUri: false,
+        requirePython: false,
+        recommendSudo: os.platform() === 'darwin' || os.platform() === 'linux',
+        requireSudo: requireSudoAccess,
+        requirePid: true,
+        pid,
+    });
+    if (!result) return false;
 
-    if (!pid) {
-        pid = await selectPid();
-    }
-    if (!pid) return false;
-    runTask(context, workspaceFolder, pySpyPath, `--pid ${pid}`, flags, needsSudoAccess, filenameToJupyterCellMap);
+    const { pid: verifiedPid, pySpyPath, workspaceFolder } = result;
+
+    const task = createProfileTask(
+        workspaceFolder,
+        {
+            type: 'flamegraph',
+            profilerPath: pySpyPath,
+            pid: verifiedPid,
+            native,
+            subprocesses,
+        },
+        TASK_TERMINAL_NAME,
+        silent
+    );
+    await vscode.tasks.executeTask(task);
     return true;
 }
 
 /**
  * Attaches py-spy to the running process with the --subprocesses flag.
  *
- * @param context - The extension context.
  * @returns The command registration.
  */
-export function attachProfilerCommand(context: vscode.ExtensionContext) {
+export function attachProfilerCommand() {
     return vscode.commands.registerCommand('flamegraph.attachProfiler', async () => {
-        await attach(context, '--subprocesses');
+        await attach();
     });
 }
 
 /**
  * Attaches py-spy to the running process with the --native flag.
  *
- * @param context - The extension context.
  * @returns The command registration.
  */
-export function attachNativeProfilerCommand(context: vscode.ExtensionContext) {
+export function attachNativeProfilerCommand() {
     return vscode.commands.registerCommand('flamegraph.attachNativeProfiler', async () => {
-        await attach(context, '--native');
+        await attach(undefined, false, true);
     });
 }
 
@@ -321,21 +236,17 @@ export function showFlamegraphCommand(context: vscode.ExtensionContext) {
 /**
  * Helper function to handle notebook profiling logic.
  *
- * @param context - The extension context.
  * @param notebook - The notebook document.
  * @param executeCommand - The command to execute after profiling.
  */
-async function handleNotebookProfiling(
-    context: vscode.ExtensionContext,
-    notebook: vscode.NotebookDocument,
-    executeCommand: () => Promise<void>
-) {
+async function handleNotebookProfiling(notebook: vscode.NotebookDocument, executeCommand: () => Promise<void>) {
     const result = await getPidAndCellFilenameMap(notebook);
     if (!result) return;
 
-    const { pid, filenameToJupyterCellMap } = result;
+    const { pid } = result;
+    extensionState.filenameToJupyterCellMap = result.filenameToJupyterCellMap;
 
-    const success = await attach(context, '--subprocesses', pid, filenameToJupyterCellMap, true);
+    const success = await attach(pid, true, false, true, true);
     if (!success) return;
 
     // small delay to ensure py-spy is running
@@ -355,16 +266,15 @@ async function handleNotebookProfiling(
 /**
  * Profiles the currently selected cell in the active notebook.
  *
- * @param context - The extension context.
  * @returns The command registration.
  */
-export function profileCellCommand(context: vscode.ExtensionContext) {
+export function profileCellCommand() {
     return vscode.commands.registerCommand('flamegraph.profileCell', async (cell?: vscode.NotebookCell) => {
         if (!cell) {
             return;
         }
 
-        await handleNotebookProfiling(context, cell.notebook, async () =>
+        await handleNotebookProfiling(cell.notebook, async () =>
             commands.executeCommand(
                 'notebook.cell.execute',
                 { start: cell.index, end: cell.index + 1 },
@@ -377,10 +287,9 @@ export function profileCellCommand(context: vscode.ExtensionContext) {
 /**
  * Profiles the currently active notebook.
  *
- * @param context - The extension context.
  * @returns The command registration.
  */
-export function profileNotebookCommand(context: vscode.ExtensionContext) {
+export function profileNotebookCommand() {
     return vscode.commands.registerCommand('flamegraph.profileNotebook', async () => {
         const notebookEditor = vscode.window.activeNotebookEditor;
         if (!notebookEditor) {
@@ -388,41 +297,37 @@ export function profileNotebookCommand(context: vscode.ExtensionContext) {
             return;
         }
 
-        await handleNotebookProfiling(context, notebookEditor.notebook, async () =>
+        await handleNotebookProfiling(notebookEditor.notebook, async () =>
             commands.executeCommand('notebook.execute', notebookEditor.notebook.uri)
         );
     });
 }
 
+/**
+ * Attaches py-spy to a pid and show a top-like view in the task terminal.
+ *
+ * @returns The command registration.
+ */
 export function topCommand() {
     return vscode.commands.registerCommand('flamegraph.top', async () => {
-        const pid = await selectPid();
-        if (!pid) return;
+        const result = await verify({
+            requireUri: false,
+            requirePython: false,
+            recommendSudo: os.platform() === 'darwin' || os.platform() === 'linux',
+            requireSudo: false,
+            requirePid: true,
+        });
+        if (!result) return false;
 
-        const needsSudoAccess = os.platform() === 'darwin' || os.platform() === 'linux';
-        const pySpyPath = await getOrInstallPySpyWithSudo(needsSudoAccess, false);
-        if (!pySpyPath) return;
+        const { pid: verifiedPid, pySpyPath, workspaceFolder } = result;
 
-        const sudo = needsSudoAccess ? 'sudo ' : '';
-        const ampersand = os.platform() === 'win32' ? '& ' : '';
-        // Create task definition
-        const taskDefinition: vscode.TaskDefinition = {
-            type: 'shell',
-            command: escapeSpaces(`${ampersand}${sudo}"${pySpyPath}" top --pid ${pid}`),
-        };
-        // Create the task
-        const task = new vscode.Task(
-            taskDefinition,
-            vscode.workspace.workspaceFolders![0],
-            TASK_TERMINAL_NAME,
-            'py-spy',
-            new vscode.ShellExecution(taskDefinition.command, {
-                executable: os.platform() === 'win32' ? 'powershell.exe' : undefined,
-            }),
-            []
-        );
-
-        // Execute the task
+        const task = createProfileTask(workspaceFolder, {
+            type: 'flamegraph',
+            profilerPath: pySpyPath,
+            pid: verifiedPid,
+            mode: 'top',
+        });
         await vscode.tasks.executeTask(task);
+        return true;
     });
 }

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -57,6 +57,11 @@ export interface FlamegraphTaskDefinition extends vscode.TaskDefinition {
      * The path to the profiler (optional)
      */
     profilerPath?: string;
+
+    /**
+     * Whether to run the task with sudo (optional)
+     */
+    sudo?: boolean;
 }
 
 /**
@@ -79,7 +84,7 @@ export function createProfileTask(
     profilerPath: string | undefined = undefined
 ): vscode.Task {
     let command = '';
-    const sudo = os.platform() === 'darwin' ? 'sudo ' : '';
+    const sudo = definition.sudo || os.platform() === 'darwin' ? 'sudo ' : '';
     const ampersand = os.platform() === 'win32' ? '& ' : '';
     const mode = definition.mode || 'record';
 
@@ -104,7 +109,7 @@ export function createProfileTask(
         definition,
         workspaceFolder,
         name,
-        'py-spy',
+        'Flamegraph',
         new vscode.ShellExecution(command, {
             executable: os.platform() === 'win32' ? 'powershell.exe' : undefined,
         }),

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -1,0 +1,225 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as os from 'os';
+import { getPythonPath, getPySpyPath } from './utilities/fsUtils';
+import { escapeSpaces } from './utilities/pathUtils';
+
+export const PROFILE_FILENAME = 'profile.pyspy';
+
+/**
+ * Task definition for the flamegraph profiler tasks. This will be used to execute the py-spy command
+ * `{py-spy-path} <py-spy-args, i.e. --subprocesses --native> {record|top} -- {python-path} {file} {args}`
+ * or
+ * `{py-spy-path} <py-spy-args, i.e. --subprocesses --native> {record|top} --pid {pid}`
+ */
+export interface FlamegraphTaskDefinition extends vscode.TaskDefinition {
+    /**
+     * The type of the task (should be 'flamegraph')
+     */
+    type: 'flamegraph';
+
+    /**
+     * The mode of the task (should be 'record' or 'top')
+     */
+    mode?: 'record' | 'top';
+
+    /**
+     * The python file to profile (optional)
+     */
+    file?: string;
+
+    /**
+     * The process ID to attach to, should only be provided if file is not provided (optional)
+     */
+    pid?: string;
+
+    /**
+     * Profile subprocesses (optional)
+     */
+    subprocesses?: boolean;
+
+    /**
+     * Use native profiling (optional)
+     */
+    native?: boolean;
+
+    /**
+     * The arguments to pass to the profiler (optional).
+     */
+    args?: string[];
+
+    /**
+     * The path to the Python interpreter (optional)
+     */
+    pythonPath?: string;
+
+    /**
+     * The path to the profiler (optional)
+     */
+    profilerPath?: string;
+}
+
+/**
+ * Creates a profiling task based on the task definition
+ *
+ * @param workspaceFolder - The workspace folder to run the task in
+ * @param definition - The task definition
+ * @param name - The name of the task
+ * @param silent - Whether to run the task silently
+ * @param pythonPath - The path to the Python interpreter
+ * @param profilerPath - The path to the profiler
+ * @returns The flamegraph profiling task
+ */
+export function createProfileTask(
+    workspaceFolder: vscode.WorkspaceFolder,
+    definition: FlamegraphTaskDefinition,
+    name: string = 'Flamegraph',
+    silent: boolean = false,
+    pythonPath: string | undefined = undefined,
+    profilerPath: string | undefined = undefined
+): vscode.Task {
+    let command = '';
+    const sudo = os.platform() === 'darwin' ? 'sudo ' : '';
+    const ampersand = os.platform() === 'win32' ? '& ' : '';
+    const mode = definition.mode || 'record';
+
+    const pySpyArgs = [
+        `${ampersand}${sudo}"${profilerPath || definition.profilerPath}" ${mode}`,
+        mode === 'record' ? `--output ${PROFILE_FILENAME}` : '',
+        mode === 'record' ? '--format raw' : '',
+        mode === 'record' ? '--full-filenames' : '',
+        definition.subprocesses ? '--subprocesses' : '',
+        definition.native ? '--native' : '',
+        definition.pid ? `--pid ${definition.pid}` : '',
+        definition.pythonPath || pythonPath ? `-- "${definition.pythonPath || pythonPath}"` : '',
+        definition.file ? `"${definition.file}"` : '',
+    ]
+        .filter(Boolean)
+        .join(' ');
+
+    const argsStr = definition.args ? definition.args.map((arg) => `"${arg}"`).join(' ') : '';
+    command = escapeSpaces(`${pySpyArgs} ${argsStr}`);
+
+    const task = new vscode.Task(
+        definition,
+        workspaceFolder,
+        name,
+        'py-spy',
+        new vscode.ShellExecution(command, {
+            executable: os.platform() === 'win32' ? 'powershell.exe' : undefined,
+        }),
+        []
+    );
+
+    if (silent) {
+        task.presentationOptions = {
+            reveal: vscode.TaskRevealKind.Silent,
+            panel: vscode.TaskPanelKind.Shared,
+            clear: false,
+        };
+    }
+
+    return task;
+}
+
+/**
+ * Task provider for flamegraph profiling tasks
+ */
+export class FlamegraphTaskProvider implements vscode.TaskProvider {
+    static taskType = 'flamegraph';
+
+    /**
+     * Provides the flamegraph profiling tasks
+     *
+     * @returns The flamegraph profiling tasks
+     */
+    public async provideTasks(): Promise<vscode.Task[]> {
+        // Get the workspace folder
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            return [];
+        }
+        const pythonPath = await getPythonPath();
+        if (!pythonPath) {
+            return [];
+        }
+        const profilerPath = await getPySpyPath();
+        if (!profilerPath) {
+            return [];
+        }
+
+        const tasks = [];
+
+        // Get active editor to suggest profiling the current file
+        const editor = vscode.window.activeTextEditor;
+        if (editor && editor.document.uri.fsPath.endsWith('.py')) {
+            const filePath = editor.document.uri.fsPath;
+            const fileName = path.basename(filePath);
+
+            // Add profile current file task as the only example task
+            tasks.push(
+                createProfileTask(
+                    workspaceFolder,
+                    {
+                        type: 'flamegraph',
+                        file: filePath,
+                        subprocesses: true,
+                        pythonPath,
+                        profilerPath,
+                    },
+                    `Profile ${fileName}`
+                )
+            );
+
+            tasks.push(
+                createProfileTask(
+                    workspaceFolder,
+                    {
+                        type: 'flamegraph',
+                        args: ['-m', 'pytest', `${filePath}`],
+                        pythonPath,
+                        profilerPath,
+                    },
+                    `Profile pytests in ${fileName}`
+                )
+            );
+        }
+        tasks.push(
+            createProfileTask(
+                workspaceFolder,
+                { type: 'flamegraph', args: ['-m', 'pytest'], pythonPath, profilerPath },
+                `Profile all pytests`
+            )
+        );
+
+        return tasks;
+    }
+
+    /**
+     * Resolves a task from a task definition
+     *
+     * @param task - The task to resolve
+     * @returns The resolved task
+     */
+    public async resolveTask(task: vscode.Task): Promise<vscode.Task | undefined> {
+        const definition = task.definition as FlamegraphTaskDefinition;
+
+        if (definition.type !== FlamegraphTaskProvider.taskType) {
+            return undefined;
+        }
+
+        const workspaceFolder = task.scope as vscode.WorkspaceFolder;
+        if (!workspaceFolder) {
+            return undefined;
+        }
+
+        return createProfileTask(
+            workspaceFolder,
+            definition,
+            task.name,
+            false,
+            definition.pythonPath || (await getPythonPath()),
+            definition.profilerPath || (await getPySpyPath())
+        );
+    }
+}


### PR DESCRIPTION
Task have now been refactored in the file `taskProvider.ts` that uses the VS Code Task API. This addresses #5

Now it's possible to add custom tasks in the `tasks.json` file in the .vscode folder. For example, the following task
```json
{
	"version": "2.0.0",
	"tasks": [
		{
			"type": "flamegraph",
			"file": "${file}",
			"args": [
				"--my-custom-arg1",
				"value",
			],
			"label": "Flamegraph: My custom profile command"
		}
	]
}
```
will execute the command

```py-spy <py-spy-args> -- python <current-file> --my-custom-arg1 value```.

Or, we can profile a unit test via
```json
{
	"version": "2.0.0",
	"tasks": [
		{
			"type": "flamegraph",
			"args": [
				"-m",
				"pytest",
				"path/to/my_test_file.py::test_my_function",
			],
			"subprocesses": false,
			"native": true,
			"label": "Flamegraph: Profile my_test_function"
		}
	]
}
```
which runs
```py-spy <py-spy-args> --native -- python -m pytest path/to/my_test_file.py::test_my_function```
