### PR TITLE
Add tooltips to flamegraph legend

### DIFF
--- a/flamegraph-react/package-lock.json
+++ b/flamegraph-react/package-lock.json
@@ -5622,9 +5622,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001680",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
-            "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
+            "version": "1.0.30001710",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001710.tgz",
+            "integrity": "sha512-B5C0I0UmaGqHgo5FuqJ7hBd4L57A4dDD+Xi+XX1nXOoxGeDdY4Ko38qJYOyqznBVJEqON5p8P1x5zRR3+rsnxA==",
             "dev": true,
             "funding": [
                 {
@@ -23017,9 +23017,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001680",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
-            "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
+            "version": "1.0.30001710",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001710.tgz",
+            "integrity": "sha512-B5C0I0UmaGqHgo5FuqJ7hBd4L57A4dDD+Xi+XX1nXOoxGeDdY4Ko38qJYOyqznBVJEqON5p8P1x5zRR3+rsnxA==",
             "dev": true
         },
         "case-sensitive-paths-webpack-plugin": {

--- a/flamegraph-react/src/components/Flamegraph.tsx
+++ b/flamegraph-react/src/components/Flamegraph.tsx
@@ -37,6 +37,51 @@ export function FlameGraph({
         [hiddenModules, root, functions]
     );
 
+    const { moduleSamples, moduleOwnSamples, totalSamples } = useMemo(() => {
+        let totalSamples = 0;
+
+        function getModuleInfo(
+            node: Flamenode,
+            currentPath: string[] = [],
+            moduleSamples: Map<string, number> = new Map(),
+            moduleOwnSamples: Map<string, number> = new Map()
+        ): { moduleSamples: Map<string, number>; moduleOwnSamples: Map<string, number> } {
+            // Get the module of current node
+            const currentModule = functions[node.functionId]?.module;
+
+            // If module exists and hasn't been visited in current path, we can count it towards the module samples
+            if (currentModule) {
+                if (!currentPath.includes(currentModule)) {
+                    moduleSamples.set(currentModule, (moduleSamples.get(currentModule) || 0) + node.samples);
+                }
+                // Add to current path to track that we have already counted
+                currentPath.push(currentModule);
+            }
+
+            const childrenSamples = node.children.reduce((acc, child) => acc + child.samples, 0);
+            const ownSamples = node.samples - childrenSamples;
+            totalSamples += ownSamples;
+            if (currentModule) {
+                moduleOwnSamples.set(currentModule, (moduleOwnSamples.get(currentModule) || 0) + ownSamples);
+            }
+
+            // Recursively process children
+            for (const child of node.children) {
+                getModuleInfo(child, currentPath, moduleSamples, moduleOwnSamples);
+            }
+
+            // Remove from path if it was added (when backtracking)
+            if (currentModule) {
+                currentPath.pop();
+            }
+
+            return { moduleSamples, moduleOwnSamples };
+        }
+
+        const { moduleSamples, moduleOwnSamples } = getModuleInfo(filteredRoot);
+        return { moduleSamples, moduleOwnSamples, totalSamples };
+    }, [filteredRoot, functions]);
+
     const [focusNode, setFocusNode] = useState<Flamenode>(filteredRoot);
     const [hoveredLineId, setHoveredLineId] = useState<number | null>(null);
     const [hoveredFunctionId, setHoveredFunctionId] = useState<number | null>(null);
@@ -239,6 +284,9 @@ export function FlameGraph({
                         return next;
                     });
                 }}
+                moduleSamples={moduleSamples}
+                moduleOwnSamples={moduleOwnSamples}
+                totalSamples={totalSamples}
             />
         </div>
     );

--- a/flamegraph-react/src/components/Legend.tsx
+++ b/flamegraph-react/src/components/Legend.tsx
@@ -6,9 +6,19 @@ interface LegendProps {
     items: LegendItem[];
     onModuleVisibilityChange: (moduleName: string, isVisible: boolean) => void;
     hiddenModules: Set<string>;
+    moduleSamples: Map<string, number>;
+    moduleOwnSamples: Map<string, number>;
+    totalSamples: number;
 }
 
-export function Legend({ items, onModuleVisibilityChange, hiddenModules }: LegendProps) {
+export function Legend({
+    items,
+    onModuleVisibilityChange,
+    hiddenModules,
+    moduleSamples,
+    moduleOwnSamples,
+    totalSamples,
+}: LegendProps) {
     if (items.length === 0) return null;
 
     return (
@@ -17,8 +27,18 @@ export function Legend({ items, onModuleVisibilityChange, hiddenModules }: Legen
                 <div className="flex items-center gap-6 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
                     {items.map(({ name, hue }) => {
                         const isHidden = hiddenModules.has(name);
+                        const samples = moduleSamples.get(name) || 0;
+                        const ownSamples = moduleOwnSamples.get(name) || 0;
                         return (
-                            <div key={name} className="flex items-center gap-1.5">
+                            <div
+                                key={name}
+                                className="flex items-center gap-1.5"
+                                {...(samples > 0
+                                    ? {
+                                          title: `Time: ${samples / 100}s (${((samples / totalSamples) * 100).toFixed(1)}%) / Own time: ${ownSamples / 100}s${ownSamples > 0 ? ` (${((ownSamples / totalSamples) * 100).toFixed(1)}%)` : ''}`,
+                                      }
+                                    : {})}
+                            >
                                 <label className="flex items-center cursor-pointer">
                                     <input
                                         type="checkbox"

--- a/flamegraph-react/src/components/Legend.tsx
+++ b/flamegraph-react/src/components/Legend.tsx
@@ -33,7 +33,7 @@ export function Legend({
                             <div
                                 key={name}
                                 className="flex items-center gap-1.5"
-                                {...(samples > 0
+                                {...(samples > 0 && totalSamples > 0
                                     ? {
                                           title: `Time: ${samples / 100}s (${((samples / totalSamples) * 100).toFixed(1)}%) / Own time: ${ownSamples / 100}s${ownSamples > 0 ? ` (${((ownSamples / totalSamples) * 100).toFixed(1)}%)` : ''}`,
                                       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2704,9 +2704,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001699",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
-            "integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
+            "version": "1.0.30001710",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001710.tgz",
+            "integrity": "sha512-B5C0I0UmaGqHgo5FuqJ7hBd4L57A4dDD+Xi+XX1nXOoxGeDdY4Ko38qJYOyqznBVJEqON5p8P1x5zRR3+rsnxA==",
             "dev": true,
             "funding": [
                 {

--- a/src/utilities/pathUtils.ts
+++ b/src/utilities/pathUtils.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, normalize } from 'path';
+import { isAbsolute } from 'path';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';


### PR DESCRIPTION
Add tooltips to legends that show timing info: total time of a module and own time of a module. Resolves #7 

These times are obtained by DFS traversal of the tree.
1. Time - in a given path from root to leave, samples are counted towards total module time for the first module occurrence in the path.
2. Own time - for every node, the own time is computed by "node samples - samples of all children" and is added to the module count.

<img width="721" alt="image" src="https://github.com/user-attachments/assets/5b20147c-9084-4d85-98ef-b8429e973f16" />
