### PR TITLE
Fix flamegraph serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [unreleased]
+### Fixed
+- Resolved rendering issues with deeply nested flamegraphs in the webview panel caused by serialization recursion limits.
+
 ## [0.6.0] - 2025-06-03
 ### Added
 - Added filtering features to the flame graph legend. Users can now filter the flame graph by filename, function name, and module name through a text field. The filter feature includes advanced options for case-sensitive matching and regular expression support.
@@ -67,7 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.3.10] - 2025-04-10
 ### Changed
-- Improved legend in the flamegraph. Now, filtering by module (by deselcting items in the legend) does not reset the zoom level, unless the currently selected node is affected by the module filtering.
+- Improved legend in the flamegraph. Now, filtering by module (by deselecting items in the legend) does not reset the zoom level, unless the currently selected node is affected by the module filtering.
 - Legend items are now sorted by total time (previously they were sorted by visible area in the flamegraph).
 
 ### Added

--- a/flamegraph-react/src/App.tsx
+++ b/flamegraph-react/src/App.tsx
@@ -15,6 +15,7 @@ declare global {
 export default function Home() {
     const [parsedData, setParsedData] = useState<{
         root: Flamenode;
+        focusNode: Flamenode;
         functions: Function[];
         profileType: 'py-spy' | 'memray';
     } | null>(null);
@@ -39,7 +40,7 @@ export default function Home() {
                 addParents(root);
                 setOriginalRoot(root);
                 updateNodesWithSourceCode(root, sourceCode);
-                setParsedData({ root: focusNode, functions, profileType });
+                setParsedData({ root, focusNode, functions, profileType });
             } else if (message.type === 'source-code' && originalRoot) {
                 const sourceCodeArray = message.data as string[];
                 updateNodesWithSourceCode(originalRoot, sourceCodeArray);
@@ -66,6 +67,7 @@ export default function Home() {
             <div className="pb-12">
                 <FlameGraph
                     root={parsedData.root}
+                    initialFocusNode={parsedData.focusNode}
                     functions={parsedData.functions}
                     profileType={parsedData.profileType}
                     key={`flamegraph-${sourceCodeVersion}`}

--- a/flamegraph-react/src/components/Flamegraph.tsx
+++ b/flamegraph-react/src/components/Flamegraph.tsx
@@ -8,11 +8,13 @@ import { filterTreeByModule, getModuleInfo, filterBySearchTerm, getModuleDict } 
 
 export function FlameGraph({
     root,
+    initialFocusNode,
     functions,
     height = 23,
     profileType,
 }: {
     root: Flamenode;
+    initialFocusNode: Flamenode;
     functions: Function[];
     height?: number;
     profileType: 'py-spy' | 'memray';
@@ -69,7 +71,7 @@ export function FlameGraph({
         return getModuleInfo(root, functions);
     }, [root, functions]);
 
-    const [focusNode, setFocusNode] = useState<Flamenode>(filteredRoot);
+    const [focusNode, setFocusNode] = useState<Flamenode>(initialFocusNode);
     const [hoveredLineId, setHoveredLineId] = useState<number | null>(null);
     const [hoveredFunctionId, setHoveredFunctionId] = useState<number | null>(null);
     const [isCommandPressed, setIsCommandPressed] = useState(false);

--- a/flamegraph-react/src/components/types.ts
+++ b/flamegraph-react/src/components/types.ts
@@ -38,3 +38,7 @@ export type Flamenode = {
     sourceCode?: string;
     parent?: Flamenode;
 };
+
+export type FlattenedFlamenode = Omit<Flamenode, 'children'> & {
+    childrenUids: number[];
+};

--- a/flamegraph-react/src/utilities/flamegraphUtils.ts
+++ b/flamegraph-react/src/utilities/flamegraphUtils.ts
@@ -1,0 +1,66 @@
+import { Flamenode, FlattenedFlamenode } from '../components/types';
+
+/**
+ * Reconstructs a tree structure from flattened nodes array.
+ * @param flattenedNodes - Array of flattened nodes with childrenUids instead of children
+ * @param rootUid - UID of the root node
+ * @returns Reconstructed root node with nested children structure
+ */
+export function reconstructTreeFromFlattened(
+    flattenedNodes: FlattenedFlamenode[],
+    rootUid: number,
+    focusUid?: number
+): { root: Flamenode; focusNode: Flamenode } {
+    // Create a map for quick lookup
+    const nodeMap = new Map<number, Flamenode>();
+    flattenedNodes.forEach((node) => {
+        nodeMap.set(node.uid, { ...node, children: [] });
+    });
+
+    // Build parent-child relationships
+    flattenedNodes.forEach((flatNode) => {
+        const node = nodeMap.get(flatNode.uid);
+        if (node && flatNode.childrenUids) {
+            node.children = flatNode.childrenUids
+                .map((childUid: number) => nodeMap.get(childUid))
+                .filter(Boolean) as Flamenode[];
+        }
+    });
+
+    const root = nodeMap.get(rootUid);
+    if (!root) {
+        throw new Error(`Root node with UID ${rootUid} not found in flattened nodes`);
+    }
+
+    const focusNode = focusUid ? nodeMap.get(focusUid) || root : root;
+    return { root, focusNode };
+}
+
+/**
+ * Adds parents to the tree nodes.
+ *
+ * @param node - The node to add parents to.
+ * @param parent - The parent node.
+ */
+export function addParents(node: Flamenode, parent?: Flamenode) {
+    if (parent) node.parent = parent;
+    if (node.children) node.children.forEach((child) => addParents(child, node));
+}
+
+/**
+ * Updates the nodes with source code
+ * @param node - The node to update
+ * @param sourceCodeArray - The source code array
+ */
+export function updateNodesWithSourceCode(node: Flamenode, sourceCodeArray?: string[]) {
+    if (!sourceCodeArray) return;
+    // If the node has a UID that corresponds to an index in the sourceCodeArray
+    if (node.uid >= 0 && node.uid < sourceCodeArray.length) {
+        node.sourceCode = sourceCodeArray[node.uid];
+    }
+
+    // Process children recursively
+    if (node.children) {
+        node.children.forEach((child) => updateNodesWithSourceCode(child, sourceCodeArray));
+    }
+}

--- a/flamegraph-react/src/utilities/vscode.ts
+++ b/flamegraph-react/src/utilities/vscode.ts
@@ -26,7 +26,7 @@ class VSCodeAPIWrapper {
      * @remarks When running webview code inside a web browser, postMessage will instead
      * log the given message to the console.
      *
-     * @param message Abitrary data (must be JSON serializable) to send to the extension context.
+     * @param message Arbitrary data (must be JSON serializable) to send to the extension context.
      */
     public postMessage(message: unknown) {
         if (this.vsCodeApi) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -628,9 +628,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -678,9 +678,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1075,9 +1075,9 @@
             }
         },
         "node_modules/@jest/reporters/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2471,9 +2471,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3770,9 +3770,9 @@
             }
         },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3857,9 +3857,9 @@
             }
         },
         "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3958,9 +3958,9 @@
             }
         },
         "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4053,9 +4053,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4460,9 +4460,9 @@
             }
         },
         "node_modules/fstream/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5693,9 +5693,9 @@
             }
         },
         "node_modules/jake/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5871,9 +5871,9 @@
             }
         },
         "node_modules/jest-config/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6213,9 +6213,9 @@
             }
         },
         "node_modules/jest-runtime/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7951,9 +7951,9 @@
             }
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8714,9 +8714,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/src/flamegraph.ts
+++ b/src/flamegraph.ts
@@ -3,51 +3,17 @@ import { basename, isAbsolute } from 'path';
 import { URI } from './utilities/uri';
 import { strToHue } from './utilities/colors';
 import { getModuleName, toUnixPath, splitOutsideQuotes } from './utilities/pathUtils';
-import { NotebookCellMap, UriToCodeMap } from './types';
-
-type FrameId = number;
-type FunctionId = number;
-type LineNumber = number;
-
-export type Function = {
-    functionName: string;
-    shortFunctionName?: string;
-    filePath?: string;
-    fileName?: string;
-    shortFilename?: string;
-    module?: string;
-    moduleHue: number; // for module name
-    functionHue?: number; // for function name
-};
-
-export type Flamenode = {
-    uid: number;
-    parentUid?: number;
-    frameId: FrameId; // unique id for the frame, which is (functionName, filePath, lineNumber)
-    functionId: FunctionId; // unique id for the function, which is (functionName, filePath)
-    line?: LineNumber; // line number of the source code for this node
-    cell?: number; // cell number of the source code for this node, if the source code is in a jupyter notebook
-    sourceCode?: string; // the string of source code for this line
-    depth: number; // depth in the tree
-    samples: number; // total number of samples for this node as recorded in the profile
-    ownSamples: number; // for recursive functions, this is the number of samples for the deepest occurrence
-    children: Flamenode[];
-    enterTime?: number; // Euler tour enter time
-    exitTime?: number; // Euler tour exit time
-};
-
-type LineProfile = {
-    line: number;
-    nodes: Flamenode[];
-};
-
-type FileIndex = {
-    // map fileName to a list of matching filePaths
-    [fileName: string]: {
-        filePath: string;
-        lineProfiles: LineProfile[]; // profile data associated with lines in the file
-    }[];
-};
+import {
+    FrameId,
+    FunctionId,
+    LineNumber,
+    Flamenode,
+    FileIndex,
+    Function,
+    NotebookCellMap,
+    UriToCodeMap,
+    LineProfile,
+} from './types';
 
 export class Flamegraph {
     private frameCache: Map<string, [FrameId, FunctionId, LineNumber | undefined, number | undefined]>;

--- a/src/flamegraph.ts
+++ b/src/flamegraph.ts
@@ -237,11 +237,11 @@ export class Flamegraph {
 
                 const fileUri = this.functions[functionId].filePath;
                 const fileKey = `${fileUri}:${line}`;
-                const occurencesFileLine = sameFileLineCounts.get(fileKey) ?? 1;
-                let firstFileLineOccurence = false;
-                if (occurencesFileLine >= 1) {
-                    firstFileLineOccurence = true;
-                    sameFileLineCounts.set(fileKey, 0); // ensure that the next occurence is discarded
+                const occurrencesFileLine = sameFileLineCounts.get(fileKey) ?? 1;
+                let firstFileLineOccurrence = false;
+                if (occurrencesFileLine >= 1) {
+                    firstFileLineOccurrence = true;
+                    sameFileLineCounts.set(fileKey, 0); // ensure that the next occurrence is discarded
                 }
 
                 const existingChild = current.children.find((child) => child.frameId === frameId);
@@ -249,7 +249,7 @@ export class Flamegraph {
                 if (existingChild) {
                     current = existingChild;
                     current.samples += samples;
-                    if (occurrences === 1 && firstFileLineOccurence) current.ownSamples += samples;
+                    if (occurrences === 1 && firstFileLineOccurrence) current.ownSamples += samples;
                 } else {
                     const newNode: Flamenode = {
                         uid: this.nodes.length,
@@ -259,7 +259,7 @@ export class Flamegraph {
                         line,
                         depth: current.depth + 1,
                         samples,
-                        ownSamples: occurrences === 1 && firstFileLineOccurence ? samples : 0,
+                        ownSamples: occurrences === 1 && firstFileLineOccurrence ? samples : 0,
                         children: [],
                     };
                     current.children.push(newNode);

--- a/src/flamegraphPanel.ts
+++ b/src/flamegraphPanel.ts
@@ -188,7 +188,7 @@ export class FlamegraphPanel {
 
     /**
      * Sets up an event listener to listen for messages passed from the webview context and
-     * executes code based on the message that is recieved.
+     * executes code based on the message that is received.
      *
      * @param webview A reference to the extension webview
      */

--- a/src/flamegraphPanel.ts
+++ b/src/flamegraphPanel.ts
@@ -102,7 +102,7 @@ export class FlamegraphPanel {
                 data: {
                     flattenedNodes,
                     rootUid: flamegraph.root.uid,
-                    focusUid: extensionState.focusNode,
+                    focusUid: extensionState.focusNode.length === 1 ? extensionState.focusNode[0] : flamegraph.root.uid,
                     functions: flamegraph.functions,
                     sourceCode: extensionState.sourceCode,
                     profileType: flamegraph.profileType,

--- a/src/flamegraphPanel.ts
+++ b/src/flamegraphPanel.ts
@@ -15,6 +15,7 @@ import { getUri } from './utilities/fsUtils';
 import { getNonce } from './utilities/nonceUtils';
 import { Flamegraph } from './flamegraph';
 import { extensionState } from './state';
+import { flattenFlamegraphTree } from './utilities/flamegraphUtils';
 
 /**
  * This class manages the state and behavior of HelloWorld webview panels.
@@ -93,15 +94,19 @@ export class FlamegraphPanel {
         }
 
         if (FlamegraphPanel.currentPanel) {
+            // Flatten the tree structure to avoid JSON serialization issues with deep trees
+            const flattenedNodes = flattenFlamegraphTree(flamegraph.root);
+
             FlamegraphPanel.currentPanel._panel.webview.postMessage({
                 type: 'profile-data',
                 data: {
-                    root: flamegraph.root,
+                    flattenedNodes,
+                    rootUid: flamegraph.root.uid,
+                    focusUid: extensionState.focusNode,
                     functions: flamegraph.functions,
                     sourceCode: extensionState.sourceCode,
                     profileType: flamegraph.profileType,
                 },
-                focusUid: extensionState.focusNode,
             });
         }
     }

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
-import { Flamegraph, Flamenode } from './flamegraph';
+import { Flamegraph } from './flamegraph';
+import { Flamenode } from './types';
 import { extensionState } from './state';
 
 // TODO: Make this configurable in VS Code settings

--- a/src/test/suite/flamegraphUtils.test.ts
+++ b/src/test/suite/flamegraphUtils.test.ts
@@ -1,0 +1,341 @@
+import { flattenFlamegraphTree } from '../../utilities/flamegraphUtils';
+import { Flamenode } from '../../types';
+
+describe('flamegraphUtils', () => {
+    describe('flattenFlamegraphTree', () => {
+        test('should flatten a single node with no children', () => {
+            const root: Flamenode = {
+                uid: 1,
+                frameId: 100,
+                functionId: 200,
+                depth: 0,
+                samples: 10,
+                ownSamples: 10,
+                children: [],
+            };
+
+            const result = flattenFlamegraphTree(root);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual({
+                uid: 1,
+                frameId: 100,
+                functionId: 200,
+                depth: 0,
+                samples: 10,
+                ownSamples: 10,
+                childrenUids: [],
+            });
+        });
+
+        test('should flatten a tree with one level of children', () => {
+            const root: Flamenode = {
+                uid: 1,
+                frameId: 100,
+                functionId: 200,
+                depth: 0,
+                samples: 20,
+                ownSamples: 5,
+                children: [
+                    {
+                        uid: 2,
+                        parentUid: 1,
+                        frameId: 101,
+                        functionId: 201,
+                        depth: 1,
+                        samples: 8,
+                        ownSamples: 8,
+                        children: [],
+                    },
+                    {
+                        uid: 3,
+                        parentUid: 1,
+                        frameId: 102,
+                        functionId: 202,
+                        depth: 1,
+                        samples: 7,
+                        ownSamples: 7,
+                        children: [],
+                    },
+                ],
+            };
+
+            const result = flattenFlamegraphTree(root);
+
+            expect(result).toHaveLength(3);
+
+            // Check root node
+            expect(result[0]).toEqual({
+                uid: 1,
+                frameId: 100,
+                functionId: 200,
+                depth: 0,
+                samples: 20,
+                ownSamples: 5,
+                childrenUids: [2, 3],
+            });
+
+            // Check first child
+            expect(result[1]).toEqual({
+                uid: 2,
+                parentUid: 1,
+                frameId: 101,
+                functionId: 201,
+                depth: 1,
+                samples: 8,
+                ownSamples: 8,
+                childrenUids: [],
+            });
+
+            // Check second child
+            expect(result[2]).toEqual({
+                uid: 3,
+                parentUid: 1,
+                frameId: 102,
+                functionId: 202,
+                depth: 1,
+                samples: 7,
+                ownSamples: 7,
+                childrenUids: [],
+            });
+        });
+
+        test('should flatten a deep nested tree', () => {
+            const root: Flamenode = {
+                uid: 1,
+                frameId: 100,
+                functionId: 200,
+                depth: 0,
+                samples: 100,
+                ownSamples: 10,
+                children: [
+                    {
+                        uid: 2,
+                        parentUid: 1,
+                        frameId: 101,
+                        functionId: 201,
+                        depth: 1,
+                        samples: 90,
+                        ownSamples: 20,
+                        children: [
+                            {
+                                uid: 3,
+                                parentUid: 2,
+                                frameId: 102,
+                                functionId: 202,
+                                depth: 2,
+                                samples: 70,
+                                ownSamples: 30,
+                                children: [
+                                    {
+                                        uid: 4,
+                                        parentUid: 3,
+                                        frameId: 103,
+                                        functionId: 203,
+                                        depth: 3,
+                                        samples: 40,
+                                        ownSamples: 40,
+                                        children: [],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            const result = flattenFlamegraphTree(root);
+
+            expect(result).toHaveLength(4);
+
+            // Check that all nodes are present and relationships are preserved
+            expect(result[0].uid).toBe(1);
+            expect(result[0].childrenUids).toEqual([2]);
+
+            expect(result[1].uid).toBe(2);
+            expect(result[1].childrenUids).toEqual([3]);
+
+            expect(result[2].uid).toBe(3);
+            expect(result[2].childrenUids).toEqual([4]);
+
+            expect(result[3].uid).toBe(4);
+            expect(result[3].childrenUids).toEqual([]);
+        });
+
+        test('should preserve all optional properties', () => {
+            const root: Flamenode = {
+                uid: 1,
+                parentUid: 0,
+                frameId: 100,
+                functionId: 200,
+                line: 42,
+                cell: 1,
+                sourceCode: 'def main():',
+                depth: 0,
+                samples: 10,
+                ownSamples: 10,
+                enterTime: 100,
+                exitTime: 200,
+                children: [
+                    {
+                        uid: 2,
+                        parentUid: 1,
+                        frameId: 101,
+                        functionId: 201,
+                        line: 43,
+                        cell: 1,
+                        sourceCode: '    print("hello")',
+                        depth: 1,
+                        samples: 5,
+                        ownSamples: 5,
+                        enterTime: 110,
+                        exitTime: 150,
+                        children: [],
+                    },
+                ],
+            };
+
+            const result = flattenFlamegraphTree(root);
+
+            expect(result).toHaveLength(2);
+
+            // Check that all optional properties are preserved
+            expect(result[0]).toEqual({
+                uid: 1,
+                parentUid: 0,
+                frameId: 100,
+                functionId: 200,
+                line: 42,
+                cell: 1,
+                sourceCode: 'def main():',
+                depth: 0,
+                samples: 10,
+                ownSamples: 10,
+                enterTime: 100,
+                exitTime: 200,
+                childrenUids: [2],
+            });
+
+            expect(result[1]).toEqual({
+                uid: 2,
+                parentUid: 1,
+                frameId: 101,
+                functionId: 201,
+                line: 43,
+                cell: 1,
+                sourceCode: '    print("hello")',
+                depth: 1,
+                samples: 5,
+                ownSamples: 5,
+                enterTime: 110,
+                exitTime: 150,
+                childrenUids: [],
+            });
+        });
+
+        test('should handle complex tree with multiple branches', () => {
+            const root: Flamenode = {
+                uid: 1,
+                frameId: 100,
+                functionId: 200,
+                depth: 0,
+                samples: 100,
+                ownSamples: 10,
+                children: [
+                    {
+                        uid: 2,
+                        parentUid: 1,
+                        frameId: 101,
+                        functionId: 201,
+                        depth: 1,
+                        samples: 50,
+                        ownSamples: 10,
+                        children: [
+                            {
+                                uid: 4,
+                                parentUid: 2,
+                                frameId: 103,
+                                functionId: 203,
+                                depth: 2,
+                                samples: 40,
+                                ownSamples: 40,
+                                children: [],
+                            },
+                        ],
+                    },
+                    {
+                        uid: 3,
+                        parentUid: 1,
+                        frameId: 102,
+                        functionId: 202,
+                        depth: 1,
+                        samples: 40,
+                        ownSamples: 20,
+                        children: [
+                            {
+                                uid: 5,
+                                parentUid: 3,
+                                frameId: 104,
+                                functionId: 204,
+                                depth: 2,
+                                samples: 10,
+                                ownSamples: 10,
+                                children: [],
+                            },
+                            {
+                                uid: 6,
+                                parentUid: 3,
+                                frameId: 105,
+                                functionId: 205,
+                                depth: 2,
+                                samples: 10,
+                                ownSamples: 10,
+                                children: [],
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            const result = flattenFlamegraphTree(root);
+
+            expect(result).toHaveLength(6);
+
+            // Verify the tree structure is correctly flattened
+            const rootNode = result.find((node) => node.uid === 1);
+            expect(rootNode?.childrenUids).toEqual([2, 3]);
+
+            const node2 = result.find((node) => node.uid === 2);
+            expect(node2?.childrenUids).toEqual([4]);
+
+            const node3 = result.find((node) => node.uid === 3);
+            expect(node3?.childrenUids).toEqual([5, 6]);
+
+            const node4 = result.find((node) => node.uid === 4);
+            expect(node4?.childrenUids).toEqual([]);
+
+            const node5 = result.find((node) => node.uid === 5);
+            expect(node5?.childrenUids).toEqual([]);
+
+            const node6 = result.find((node) => node.uid === 6);
+            expect(node6?.childrenUids).toEqual([]);
+        });
+
+        test('should handle undefined children property', () => {
+            const root: Flamenode = {
+                uid: 1,
+                frameId: 100,
+                functionId: 200,
+                depth: 0,
+                samples: 10,
+                ownSamples: 10,
+                children: undefined as any,
+            };
+
+            const result = flattenFlamegraphTree(root);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].childrenUids).toEqual([]);
+        });
+    });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,2 +1,49 @@
 export type NotebookCellMap = Map<string, { cellIndex: number; cellUri: string }>;
 export type UriToCodeMap = Map<string, string>;
+export type FrameId = number;
+export type FunctionId = number;
+export type LineNumber = number;
+
+export type Function = {
+    functionName: string;
+    shortFunctionName?: string;
+    filePath?: string;
+    fileName?: string;
+    shortFilename?: string;
+    module?: string;
+    moduleHue: number; // for module name
+    functionHue?: number; // for function name
+};
+
+export type Flamenode = {
+    uid: number;
+    parentUid?: number;
+    frameId: FrameId; // unique id for the frame, which is (functionName, filePath, lineNumber)
+    functionId: FunctionId; // unique id for the function, which is (functionName, filePath)
+    line?: LineNumber; // line number of the source code for this node
+    cell?: number; // cell number of the source code for this node, if the source code is in a jupyter notebook
+    sourceCode?: string; // the string of source code for this line
+    depth: number; // depth in the tree
+    samples: number; // total number of samples for this node as recorded in the profile
+    ownSamples: number; // for recursive functions, this is the number of samples for the deepest occurrence
+    children: Flamenode[];
+    enterTime?: number; // Euler tour enter time
+    exitTime?: number; // Euler tour exit time
+};
+
+export type FlattenedFlamenode = Omit<Flamenode, 'children'> & {
+    childrenUids: number[];
+};
+
+export type LineProfile = {
+    line: number;
+    nodes: Flamenode[];
+};
+
+export type FileIndex = {
+    // map fileName to a list of matching filePaths
+    [fileName: string]: {
+        filePath: string;
+        lineProfiles: LineProfile[]; // profile data associated with lines in the file
+    }[];
+};

--- a/src/utilities/flamegraphUtils.ts
+++ b/src/utilities/flamegraphUtils.ts
@@ -1,0 +1,32 @@
+import { Flamenode, FlattenedFlamenode } from '../types';
+
+/**
+ * Flattens a flamegraph tree structure into an array to avoid JSON serialization
+ * issues with very deep nested objects. Each node stores parent UID instead of
+ * being nested in children arrays.
+ *
+ * @param root - The root node of the flamegraph to flatten.
+ * @returns An array of flattened nodes.
+ */
+export function flattenFlamegraphTree(root: Flamenode): FlattenedFlamenode[] {
+    const flattened: FlattenedFlamenode[] = [];
+
+    function traverse(node: Flamenode) {
+        const { children, ...nodeWithoutChildren } = node;
+        const flatNode = {
+            ...nodeWithoutChildren,
+            childrenUids: children?.map((child: Flamenode) => child.uid) || [],
+        };
+        flattened.push(flatNode);
+
+        // Traverse children
+        if (node.children) {
+            for (const child of node.children) {
+                traverse(child);
+            }
+        }
+    }
+
+    traverse(root);
+    return flattened;
+}


### PR DESCRIPTION
Fixes #13

Flattens flamegraphs before sending it to the web view (the web view will serialize it, which causes problems for deeply nested structures).

Additionally fixes an issue where the focusState was ignored by the flamegraph web view.