### PR TITLE
Check Scripts directory for py-spy and memray binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.3] - 2025-07-22
+### Fixed
+- Fixed an issue where py-spy and memray installations where not found on Windows in conda environments.
+
 ## [0.6.2] - 2025-07-03
 ### Fixed
 - Fixed an issue where the flame graph would not render for memray profiles with a single corrupted stack trace.

--- a/src/utilities/fsUtils.ts
+++ b/src/utilities/fsUtils.ts
@@ -168,15 +168,24 @@ export async function getPyspyPath(): Promise<string | undefined> {
         await execAsync(`py-spy --version`);
         return (await execAsync(`which py-spy`)).stdout.trim();
     } catch {
+        let pythonPath: string | undefined;
         try {
             // get python path
-            const pythonPath = await getPythonPath();
+            pythonPath = await getPythonPath();
             if (!pythonPath) return undefined;
             const profilerPath = path.join(path.dirname(pythonPath), 'py-spy');
             await execAsync(`"${profilerPath}" --version`);
             return profilerPath;
         } catch {
-            return undefined;
+            try {
+                // get python path
+                if (!pythonPath) return undefined;
+                const profilerPath = path.join(path.dirname(pythonPath), 'Scripts', 'py-spy');
+                await execAsync(`"${profilerPath}" --version`);
+                return profilerPath;
+            } catch {
+                return undefined;
+            }
         }
     }
 }
@@ -187,15 +196,20 @@ export async function getPyspyPath(): Promise<string | undefined> {
  * @returns The command to run memray or undefined if it is not installed.
  */
 export async function getMemrayPath(): Promise<string | undefined> {
+    const pythonPath = await getPythonPath();
+    if (!pythonPath) return undefined;
     try {
-        const pythonPath = await getPythonPath();
-        if (!pythonPath) return undefined;
-
         const profilerPath = path.join(path.dirname(pythonPath), 'memray');
         await execAsync(`"${profilerPath}" --version`);
         return profilerPath;
     } catch {
-        return undefined;
+        try {
+            const profilerPath = path.join(path.dirname(pythonPath), 'Scripts', 'memray');
+            await execAsync(`"${profilerPath}" --version`);
+            return profilerPath;
+        } catch {
+            return undefined;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #17

On Windows, the py-spy binary is saved in the Script folder of the python env, which was not checked by the extension. This PR is a quick workaround and I'm thinking about a more reliable solution.