### PR TITLE
fix: prevent duplicate memray task execution

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -385,10 +385,7 @@ export function runMemrayProfilerCommand() {
             },
             MEMORY_TASK_TERMINAL_NAME
         );
-
-        await vscode.tasks.executeTask(task);
-
-        // Wait for the first task to complete before running the transform task
+        // Execute the memray run task and wait for it to complete before transforming the results
         const taskExecution = await vscode.tasks.executeTask(task);
 
         // Create a promise that resolves when the task completes


### PR DESCRIPTION
## Summary
- avoid running memray profiling task twice
- ensure the transform step starts after the run task completes

## Testing
- `npm test` *(fails: Flamegraph Performance › should generate file profiles efficiently: Expected: < 5, Received: NaN)*

------
https://chatgpt.com/codex/tasks/task_e_68a21a153d28832c930b35754b8fecd5