### PR TITLE
Add UI tests for attaching profilers to running processes

### DIFF
--- a/src/ui-test/attachProfiler.test.ts
+++ b/src/ui-test/attachProfiler.test.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import { BottomBarPanel, EditorView, TerminalView, Workbench } from 'vscode-extension-tester';
+import { retryOnError } from './helpers';
+
+const PID = '999999';
+
+describe('Attach profilers', () => {
+    let bottomBar: BottomBarPanel;
+    let view: TerminalView;
+
+    before(async () => {
+        await new EditorView().closeAllEditors();
+        bottomBar = new BottomBarPanel();
+        await bottomBar.toggle(true);
+        view = await bottomBar.openTerminalView();
+    });
+
+    it(`Attach py-spy to running process`, async () => {
+        const prompt = await new Workbench().openCommandPrompt();
+        await prompt.setText('>Flamegraph: Attach py-spy to running process');
+        await prompt.confirm();
+        await retryOnError(() => prompt.setText(PID));
+        await prompt.confirm();
+        const text = await retryOnError(() => view.getText());
+        expect(text).to.contain(
+            `record --output profile.pyspy --format raw --full-filenames --subprocesses --pid ${PID}`
+        );
+        await retryOnError(() => view.killTerminal());
+    });
+
+    it(`Attach py-spy to running process with initially invalid pid`, async () => {
+        const prompt = await new Workbench().openCommandPrompt();
+        await prompt.setText('>Flamegraph: Attach py-spy to running process');
+        await prompt.confirm();
+        await retryOnError(() => prompt.setText('xxxxx'));
+        await prompt.confirm();
+        await retryOnError(() => prompt.setText(PID));
+        await prompt.confirm();
+        const text = await retryOnError(() => view.getText());
+        expect(text).to.contain(
+            `record --output profile.pyspy --format raw --full-filenames --subprocesses --pid ${PID}`
+        );
+        await retryOnError(() => view.killTerminal());
+    });
+
+    it(`Attach memray to running process`, async () => {
+        const prompt = await new Workbench().openCommandPrompt();
+        await prompt.setText('>Flamegraph: Attach memray to running process');
+        await prompt.selectQuickPick('Flamegraph: Attach memray to running process');
+        await retryOnError(() => prompt.setText(PID));
+        await prompt.confirm();
+        const text = await retryOnError(() => view.getText());
+        expect(text).to.contain(`attach --aggregate -f -o temp-memray-profile.bin ${PID}`);
+        await retryOnError(() => view.killTerminal());
+    });
+});


### PR DESCRIPTION
- Introduce a new test file `attachProfiler.test.ts` to validate the functionality of attaching profilers (py-spy and memray) to running processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add UI tests that verify attaching py-spy and memray to a running PID (including invalid PID retry) via VS Code commands and terminal output.
> 
> - **UI tests** (`src/ui-test/attachProfiler.test.ts`):
>   - Validate attaching `py-spy` to a PID and expecting `record --output profile.pyspy ... --pid 999999` in terminal output.
>   - Validate retry flow: initial invalid PID, then valid PID for `py-spy`, asserting same command output.
>   - Validate attaching `memray` to a PID, asserting `attach --aggregate -f -o temp-memray-profile.bin 999999` in terminal output.
>   - Use command palette interactions and terminal view setup/teardown for assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57b38fc08219d681519a1fdeed7af3765c3b3866. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->